### PR TITLE
Add Digital Bloom Interactive Art Playground

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "tailwindcss": "^3.4.17",
+        "tone": "^15.1.22",
         "xterm": "^5.3.0",
         "xterm-addon-fit": "^0.8.0"
       },
@@ -39,6 +40,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -1001,6 +1011,19 @@
       "license": "MIT",
       "bin": {
         "astring": "bin/astring"
+      }
+    },
+    "node_modules/automation-events": {
+      "version": "7.1.13",
+      "resolved": "https://registry.npmjs.org/automation-events/-/automation-events-7.1.13.tgz",
+      "integrity": "sha512-1Hay5TQPzxsskSqPTH3YXyzE9Iirz82zZDse2vr3+kOR7Sc7om17qIEPsESchlNX0EgKxANwR40i2g/O3GM1Tw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.2.0"
       }
     },
     "node_modules/autoprefixer": {
@@ -3713,6 +3736,17 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/standardized-audio-context": {
+      "version": "25.3.77",
+      "resolved": "https://registry.npmjs.org/standardized-audio-context/-/standardized-audio-context-25.3.77.tgz",
+      "integrity": "sha512-Ki9zNz6pKcC5Pi+QPjPyVsD9GwJIJWgryji0XL9cAJXMGyn+dPOf6Qik1AHei0+UNVcc4BOCa0hWLBzlwqsW/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.6",
+        "automation-events": "^7.0.9",
+        "tslib": "^2.7.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
@@ -4000,6 +4034,16 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tone": {
+      "version": "15.1.22",
+      "resolved": "https://registry.npmjs.org/tone/-/tone-15.1.22.tgz",
+      "integrity": "sha512-TCScAGD4sLsama5DjvTUXlLDXSqPealhL64nsdV1hhr6frPWve0DeSo63AKnSJwgfg55fhvxj0iPPRwPN5o0ag==",
+      "license": "MIT",
+      "dependencies": {
+        "standardized-audio-context": "^25.3.70",
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/trim-lines": {


### PR DESCRIPTION
## Summary
- Integrates Digital Bloom, an interactive physics-based generative art playground
- Standalone Vite application with Rust/WASM physics engine
- 7 physics modes: vine, gravity, bounce, burst, lightning, constellation, vortex
- Real-time audio synthesis with Tone.js
- Touch-optimized mobile-first design
- PWA-ready with service worker

## Architecture
```
apps/digital-bloom/          # Standalone Vite app
├── src/                     # TypeScript frontend
├── crates/                  # Rust WASM physics engine
└── public/                  # PWA assets

public/digital-bloom/        # Built output
```

## Integration Points
- **URL**: `/digital-bloom` - redirects to static HTML
- **Terminal**: New `digital-bloom` command
- **Build**: `bun run build` compiles and deploys

## Changes Made
- ✅ Fixed manifest.json icon paths to use relative paths
- ✅ Removed references to non-existent HTML elements
- ✅ Updated package-lock.json for tone dependencies

## Test Plan
- [x] Navigate to `/digital-bloom` - loads correctly
- [x] Test all 7 physics modes - interactive drawing works
- [x] Audio synthesis - notes play on interaction
- [x] Terminal command - `digital-bloom` opens app
- [x] Mobile touch interactions - responsive
- [x] WASM loading - no 404 errors
- [x] Asset paths - all resources load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)